### PR TITLE
FIX: self-assign button

### DIFF
--- a/javascripts/discourse/initializers/discourse-quick-whisper.js
+++ b/javascripts/discourse/initializers/discourse-quick-whisper.js
@@ -1,4 +1,4 @@
-import TextLib from "discourse/lib/text";
+import { cookAsync } from "discourse/lib/text";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { debounce } from "@ember/runloop";
 import { getAbsoluteURL } from "discourse-common/lib/get-url";
@@ -29,7 +29,7 @@ export default {
       // attempt to destroy any assign/unassign message related to currentUser
       // and remove previous quick whisper done by currentUser in the last 20 posts
       function cleanTopic(topic) {
-        return TextLib.cookAsync(settings.message).then((cooked) => {
+        return cookAsync(settings.message).then((cooked) => {
           if (topic.postStream && !topic.postStream.lastPostNotLoaded) {
             const posts = topic.postStream.posts.slice().reverse().slice(0, 20);
 


### PR DESCRIPTION
We've noticed that the self-assign button stopped working. This button is available in the topic controls dropdown when _in mobile view_:

<img width="350" alt="Screenshot 2023-10-10 at 23 02 05" src="https://github.com/discourse/discourse-quick-whisper/assets/1274517/a7f2327c-b665-49e4-bf88-57570dbd5723">

Currently, clicking on this button leads to this error:

    Uncaught TypeError: Cannot read properties of undefined (reading 'cookAsync')
    at discourse-quick-whisper.js:33:32
    at PluginApi.d (discourse-quick-whisper.js:54:18)
    at Backburner._join (index.ts:646:21)
    at Backburner.debounce (index.ts:522:14)
    at debounce (index.js:732:1)
    at u (discourse-quick-whisper.js:47:24)
    at Class.action (discourse-quick-whisper.js:110:13)
    at discourseComputedButton.action (register-topic-footer-button.js:130:66)
    at Class.onChange (topic-footer-mobile-dropdown.js:12:27)
    at Class._boundaryActionHandler (select-kit.js:415:42)
    at select-kit.js:330:12
    at initializePromise (rsvp.js:520:1)
    at new Promise (rsvp.js:1021:1)
    at Class._onChangeWrapper (select-kit.js:312:12)
    at Backburner._join (index.ts:646:21)
    at Backburner.join (index.ts:362:17)
    at join (index.js:165:1)
    at EmberObject.change (index.js:260:1)
    at Class.select (select-kit.js:597:22)
    at Backburner._run (index.ts:665:23)
    at Backburner._join (index.ts:640:19)
    at Backburner.join (index.ts:362:17)
    at join (index.js:165:1)
    at EmberObject.select (index.js:260:1)
    at Class.click (select-kit-row.js:91:20)
    at Class.trigger (core_view.js:68:1)
    at Class.superWrapper [as trigger] (index.js:442:1)
    at Class.trigger (ember-events.js:138:30)
    at Class.superWrapper [as trigger] (index.js:442:1)
    at HTMLLIElement.listener (ember-events.js:203:39)


Our initial guess was that this might be related to this resent commit – https://github.com/discourse/discourse/commit/fcc9d99ba256ba323eb1ebaa8b256d759eadded7, but I've tested and confirmed that the problem existed before that commit, so it regressed at some point earlier.

This PR fixes the problem by correcting an import statement. I'm not sure why the previous way of importing stopped working, but changing it as I've done solves the problem.


