### PR TITLE
FIX: self assign label was missing

### DIFF
--- a/javascripts/discourse/initializers/discourse-quick-whisper.js
+++ b/javascripts/discourse/initializers/discourse-quick-whisper.js
@@ -132,6 +132,9 @@ export default {
       api.registerTopicFooterButton({
         id: "quick-whisper",
         icon: "bolt",
+        label() {
+          return buttonLabel();
+        },
         title() {
           return buttonLabel();
         },
@@ -141,11 +144,7 @@ export default {
         dropdown: true,
         classNames: ["quick-whisper"],
         displayed() {
-          if (!this.site.mobileView || buttonLabel() === "") {
-            return false;
-          }
-
-          return true;
+          return this.site.mobileView && buttonLabel() !== "";
         },
       });
     });


### PR DESCRIPTION
The "registerTopicFooterButton" requires a label to be defined otherwise no text will be shown next to the button.

**BEFORE**

![Screenshot 2024-12-12 at 15 03 26](https://github.com/user-attachments/assets/e7974ff5-7d33-426f-877b-72b893929a22)

**AFTER**

![Screenshot 2024-12-12 at 15 03 03](https://github.com/user-attachments/assets/ed2dc453-9df6-4ae7-94db-90cd6c689eea)


